### PR TITLE
refactor type coercion

### DIFF
--- a/zig/zig_lexer.zig
+++ b/zig/zig_lexer.zig
@@ -3,7 +3,7 @@ const warn = std.debug.warn;
 
 pub usingnamespace @import("zig_grammar.tokens.zig");
 
-const identifier_state = [128]u8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0};
+const identifier_state = [128]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0 };
 
 pub const Lexer = struct {
     source: []const u8,
@@ -14,13 +14,13 @@ pub const Lexer = struct {
     pub fn init(source: []const u8) Lexer {
         return Lexer{
             .source = source,
-            .peek = if (source.len == 0) i32(-1) else @intCast(i32, source[0]),
+            .peek = if (source.len == 0) @as(i32, -1) else @intCast(i32, source[0]),
         };
     }
 
     fn getc(self: *Lexer) void {
         self.index += 1;
-        self.peek = if (self.index < self.source.len) @intCast(i32, self.source[self.index]) else i32(-1);
+        self.peek = if (self.index < self.source.len) @intCast(i32, self.source[self.index]) else @as(i32, -1);
     }
 
     fn getcx(self: *Lexer) i32 {
@@ -29,16 +29,16 @@ pub const Lexer = struct {
     }
 
     fn identifier(self: *Lexer) Id {
-        while(true) {
-            const peek: i8 = if(self.peek >= 0) @truncate(i8, self.peek) else return Id.Identifier;
-            if(peek < 0 or identifier_state[@bitCast(u8,peek)] == 0) return Id.Identifier;
+        while (true) {
+            const peek: i8 = if (self.peek >= 0) @truncate(i8, self.peek) else return Id.Identifier;
+            if (peek < 0 or identifier_state[@bitCast(u8, peek)] == 0) return Id.Identifier;
             self.getc();
         }
     }
 
     fn identifierOr(self: *Lexer, default: Id) Id {
-        const peek: i8 = if(self.peek >= 0) @truncate(i8, self.peek) else return default;
-        if(peek < 0 or identifier_state[@bitCast(u8,peek)] == 0) return default;
+        const peek: i8 = if (self.peek >= 0) @truncate(i8, self.peek) else return default;
+        if (peek < 0 or identifier_state[@bitCast(u8, peek)] == 0) return default;
         self.getc();
 
         return self.identifier();
@@ -46,17 +46,17 @@ pub const Lexer = struct {
 
     fn comment(self: *Lexer) Id {
         const id = blk: {
-            if(self.peek == '/') {
-                if(self.getcx() == '/')
+            if (self.peek == '/') {
+                if (self.getcx() == '/')
                     break :blk Id.LineComment;
                 break :blk Id.DocComment;
             }
             break :blk Id.LineComment;
         };
-        while(true) {
+        while (true) {
             switch (self.peek) {
                 '\n', -1 => return id,
-                else => {}
+                else => {},
             }
             self.getc();
         }
@@ -65,10 +65,14 @@ pub const Lexer = struct {
     fn hex(self: *Lexer) Id {
         var id = Id.Invalid;
         self.getc();
-        while(true) {
+        while (true) {
             switch (self.peek) {
-                '0'...'9','a'...'f','A'...'F' => { id = Id.IntegerLiteral; },
-                '.' => { return if(id == Id.Invalid) id else self.float_digits(true); },
+                '0'...'9', 'a'...'f', 'A'...'F' => {
+                    id = Id.IntegerLiteral;
+                },
+                '.' => {
+                    return if (id == Id.Invalid) id else self.float_digits(true);
+                },
                 else => return id,
             }
             self.getc();
@@ -78,9 +82,11 @@ pub const Lexer = struct {
     fn octal(self: *Lexer) Id {
         var id = Id.Invalid;
         self.getc();
-        while(true) {
+        while (true) {
             switch (self.peek) {
-                '0'...'7' => { id = Id.IntegerLiteral; },
+                '0'...'7' => {
+                    id = Id.IntegerLiteral;
+                },
                 else => return id,
             }
             self.getc();
@@ -90,9 +96,11 @@ pub const Lexer = struct {
     fn binary(self: *Lexer) Id {
         var id = Id.Invalid;
         self.getc();
-        while(true) {
+        while (true) {
             switch (self.peek) {
-                '0'...'1' => { id = Id.IntegerLiteral; },
+                '0'...'1' => {
+                    id = Id.IntegerLiteral;
+                },
                 else => return id,
             }
             self.getc();
@@ -100,7 +108,7 @@ pub const Lexer = struct {
     }
 
     fn digits(self: *Lexer) Id {
-        while(true) {
+        while (true) {
             switch (self.peek) {
                 '0'...'9' => {},
                 '.', 'e' => return self.float_digits(false),
@@ -112,14 +120,16 @@ pub const Lexer = struct {
 
     fn float_digits(self: *Lexer, allow_hex: bool) Id {
         self.getc();
-        if(self.peek == '.') {
+        if (self.peek == '.') {
             self.index -= 1;
             return Id.IntegerLiteral;
         }
-        while(true) {
+        while (true) {
             switch (self.peek) {
                 '0'...'9' => {},
-                'a'...'f','A'...'F' => { if(!allow_hex) return Id.FloatLiteral; },
+                'a'...'f', 'A'...'F' => {
+                    if (!allow_hex) return Id.FloatLiteral;
+                },
                 else => return Id.FloatLiteral,
             }
             self.getc();
@@ -127,10 +137,10 @@ pub const Lexer = struct {
     }
 
     fn linestring(self: *Lexer, id: Id) Id {
-        while(true) {
+        while (true) {
             switch (self.peek) {
                 '\n', -1 => return id,
-                else => {}
+                else => {},
             }
             self.getc();
         }
@@ -157,17 +167,17 @@ pub const Lexer = struct {
     }
 
     pub fn next(self: *Lexer) Token {
-        while(true) {
+        while (true) {
             self.first = self.index;
 
-            const peek: i8 = if(self.peek >= 0) @truncate(i8, self.peek) else return Token{ .start = self.first, .end = self.index, .id = Id.Eof};
-            if(peek < 0) {
+            const peek: i8 = if (self.peek >= 0) @truncate(i8, self.peek) else return Token{ .start = self.first, .end = self.index, .id = Id.Eof };
+            if (peek < 0) {
                 self.getc();
-                return Token{ .start = self.first, .end = self.index, .id = Id.Invalid};
+                return Token{ .start = self.first, .end = self.index, .id = Id.Invalid };
             }
 
             const id = self.nextId(peek);
-            if(id != .Ignore)
+            if (id != .Ignore)
                 return Token{ .start = self.first, .end = self.index, .id = id };
         }
     }
@@ -179,11 +189,11 @@ pub const Lexer = struct {
                 return Id.Newline;
             },
             ' ' => {
-                while(self.peek == ' ') self.getc();
+                while (self.peek == ' ') self.getc();
                 return Id.Ignore;
             },
             '!' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.BangEqual;
                 }
@@ -193,25 +203,25 @@ pub const Lexer = struct {
                 return self.string();
             },
             '#' => {
-                if(self.index == 1 and self.peek == '!') {
-                    while(self.peek != '\n' and self.peek != -1) self.getc();
+                if (self.index == 1 and self.peek == '!') {
+                    while (self.peek != '\n' and self.peek != -1) self.getc();
                     return Id.ShebangLine;
                 }
                 return Id.Invalid;
             },
             '%' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.PercentEqual;
                 }
                 return Id.Percent;
             },
             '&' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.AmpersandEqual;
                 }
-                if(self.peek == '&') {
+                if (self.peek == '&') {
                     self.getc();
                     return Id.AmpersandAmpersand;
                 }
@@ -223,8 +233,8 @@ pub const Lexer = struct {
                         '\n', -1 => return Id.Invalid,
                         '\\' => {
                             const escape = self.getcx();
-                            if(escape == '\n' or escape == -1)
-                                // TODO: error
+                            if (escape == '\n' or escape == -1)
+                            // TODO: error
                                 return Id.Identifier;
                         },
                         '\'' => {
@@ -243,38 +253,38 @@ pub const Lexer = struct {
                 return Id.RParen;
             },
             '*' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.AsteriskEqual;
                 }
-                if(self.peek == '%') {
+                if (self.peek == '%') {
                     self.getc();
-                    if(self.peek == '=') {
+                    if (self.peek == '=') {
                         self.getc();
                         return Id.AsteriskPercentEqual;
                     }
                     return Id.AsteriskPercent;
                 }
-                if(self.peek == '*') {
+                if (self.peek == '*') {
                     self.getc();
                     return Id.AsteriskAsterisk;
                 }
                 return Id.Asterisk;
             },
             '+' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.PlusEqual;
                 }
-                if(self.peek == '%') {
+                if (self.peek == '%') {
                     self.getc();
-                    if(self.peek == '=') {
+                    if (self.peek == '=') {
                         self.getc();
                         return Id.PlusPercentEqual;
                     }
                     return Id.PlusPercent;
                 }
-                if(self.peek == '+') {
+                if (self.peek == '+') {
                     self.getc();
                     return Id.PlusPlus;
                 }
@@ -284,49 +294,49 @@ pub const Lexer = struct {
                 return Id.Comma;
             },
             '-' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.MinusEqual;
                 }
-                if(self.peek == '%') {
+                if (self.peek == '%') {
                     self.getc();
-                    if(self.peek == '=') {
+                    if (self.peek == '=') {
                         self.getc();
                         return Id.MinusPercentEqual;
                     }
                     return Id.MinusPercent;
                 }
-                if(self.peek == '>') {
+                if (self.peek == '>') {
                     self.getc();
                     return Id.MinusAngleBracketRight;
                 }
                 return Id.Minus;
             },
             '.' => {
-                if(self.peek == '.') {
+                if (self.peek == '.') {
                     self.getc();
-                    if(self.peek == '.') {
+                    if (self.peek == '.') {
                         self.getc();
                         return Id.Ellipsis3;
                     }
                     return Id.Ellipsis2;
                 }
-                if(self.peek == '?') {
+                if (self.peek == '?') {
                     self.getc();
                     return Id.PeriodQuestionMark;
                 }
-                if(self.peek == '*') {
+                if (self.peek == '*') {
                     self.getc();
                     return Id.PeriodAsterisk;
                 }
                 return Id.Period;
             },
             '/' => {
-                if(self.peek == '/') {
+                if (self.peek == '/') {
                     self.getc();
                     return self.comment();
                 }
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.SlashEqual;
                 }
@@ -339,13 +349,13 @@ pub const Lexer = struct {
                 return Id.Semicolon;
             },
             '<' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.AngleBracketLeftEqual;
                 }
-                if(self.peek == '<') {
+                if (self.peek == '<') {
                     self.getc();
-                    if(self.peek == '=') {
+                    if (self.peek == '=') {
                         self.getc();
                         return Id.AngleBracketAngleBracketLeftEqual;
                     }
@@ -354,24 +364,24 @@ pub const Lexer = struct {
                 return Id.AngleBracketLeft;
             },
             '=' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.EqualEqual;
                 }
-                if(self.peek == '>') {
+                if (self.peek == '>') {
                     self.getc();
                     return Id.EqualAngleBracketRight;
                 }
                 return Id.Equal;
             },
             '>' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.AngleBracketRightEqual;
                 }
-                if(self.peek == '>') {
+                if (self.peek == '>') {
                     self.getc();
-                    if(self.peek == '=') {
+                    if (self.peek == '=') {
                         self.getc();
                         return Id.AngleBracketAngleBracketRightEqual;
                     }
@@ -383,45 +393,45 @@ pub const Lexer = struct {
                 return Id.QuestionMark;
             },
             '@' => {
-                if(self.peek == '"') {
-                    while(true) {
-                        switch(self.getcx()) {
-                            '\n',-1 => {
+                if (self.peek == '"') {
+                    while (true) {
+                        switch (self.getcx()) {
+                            '\n', -1 => {
                                 // TODO: error
                                 return Id.Identifier;
                             },
                             '\\' => {
                                 const escape = self.getcx();
-                                if(escape == '\n' or escape == -1)
-                                    // TODO: error
+                                if (escape == '\n' or escape == -1)
+                                // TODO: error
                                     return Id.Identifier;
                             },
                             '"' => {
                                 self.getc();
                                 return Id.Identifier;
                             },
-                            else => {}
+                            else => {},
                         }
                     }
                 }
                 _ = self.identifier();
-                if(self.first+1 < self.index)
+                if (self.first + 1 < self.index)
                     return Id.Builtin;
                 return Id.Invalid;
             },
             '[' => {
-                if(self.peek == '*') {
+                if (self.peek == '*') {
                     self.getc();
-                    if(self.peek == 'c') {
+                    if (self.peek == 'c') {
                         self.getc();
-                        if(self.peek == ']') {
+                        if (self.peek == ']') {
                             self.getc();
                             return Id.BracketStarCBracket;
                         }
                         self.index -= 2;
                         return Id.LBracket;
                     }
-                    if(self.peek == ']') {
+                    if (self.peek == ']') {
                         self.getc();
                         return Id.BracketStarBracket;
                     }
@@ -430,7 +440,7 @@ pub const Lexer = struct {
                 return Id.LBracket;
             },
             '\\' => {
-                if(self.peek == '\\') {
+                if (self.peek == '\\') {
                     self.getc();
                     return self.linestring(Id.LineString);
                 }
@@ -440,7 +450,7 @@ pub const Lexer = struct {
                 return Id.RBracket;
             },
             '^' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.CaretEqual;
                 }
@@ -448,54 +458,54 @@ pub const Lexer = struct {
             },
             'a' => {
                 //Keyword_and
-                if(self.peek == 'n') {
-                    if(self.getcx() != 'd') return self.identifier();
+                if (self.peek == 'n') {
+                    if (self.getcx() != 'd') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_and);
                 }
-                if(self.peek == 's') {
+                if (self.peek == 's') {
                     self.getc();
                     //Keyword_async
-                    if(self.peek == 'y') {
-                        if(self.getcx() != 'n') return self.identifier();
-                        if(self.getcx() != 'c') return self.identifier();
+                    if (self.peek == 'y') {
+                        if (self.getcx() != 'n') return self.identifier();
+                        if (self.getcx() != 'c') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_async);
                     }
                     //Keyword_asm
-                    if(self.peek == 'm') {
+                    if (self.peek == 'm') {
                         self.getc();
                         return self.identifierOr(Id.Keyword_asm);
                     }
                     return self.identifier();
                 }
-                if(self.peek == 'l') {
+                if (self.peek == 'l') {
                     self.getc();
                     //Keyword_align
-                    if(self.peek == 'i') {
-                        if(self.getcx() != 'g') return self.identifier();
-                        if(self.getcx() != 'n') return self.identifier();
+                    if (self.peek == 'i') {
+                        if (self.getcx() != 'g') return self.identifier();
+                        if (self.getcx() != 'n') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_align);
                     }
                     //Keyword_allowzero
-                    if(self.peek == 'l') {
-                        if(self.getcx() != 'o') return self.identifier();
-                        if(self.getcx() != 'w') return self.identifier();
-                        if(self.getcx() != 'z') return self.identifier();
-                        if(self.getcx() != 'e') return self.identifier();
-                        if(self.getcx() != 'r') return self.identifier();
-                        if(self.getcx() != 'o') return self.identifier();
+                    if (self.peek == 'l') {
+                        if (self.getcx() != 'o') return self.identifier();
+                        if (self.getcx() != 'w') return self.identifier();
+                        if (self.getcx() != 'z') return self.identifier();
+                        if (self.getcx() != 'e') return self.identifier();
+                        if (self.getcx() != 'r') return self.identifier();
+                        if (self.getcx() != 'o') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_allowzero);
                     }
                     return self.identifier();
                 }
                 //Keyword_await
-                if(self.peek == 'w') {
-                    if(self.getcx() != 'a') return self.identifier();
-                    if(self.getcx() != 'i') return self.identifier();
-                    if(self.getcx() != 't') return self.identifier();
+                if (self.peek == 'w') {
+                    if (self.getcx() != 'a') return self.identifier();
+                    if (self.getcx() != 'i') return self.identifier();
+                    if (self.getcx() != 't') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_await);
                 }
@@ -503,137 +513,137 @@ pub const Lexer = struct {
             },
             'b' => {
                 //Keyword_break
-                if(self.peek != 'r') return self.identifier();
-                if(self.getcx() != 'e') return self.identifier();
-                if(self.getcx() != 'a') return self.identifier();
-                if(self.getcx() != 'k') return self.identifier();
+                if (self.peek != 'r') return self.identifier();
+                if (self.getcx() != 'e') return self.identifier();
+                if (self.getcx() != 'a') return self.identifier();
+                if (self.getcx() != 'k') return self.identifier();
                 self.getc();
                 return self.identifierOr(Id.Keyword_break);
             },
             'c' => {
-                if(self.peek == 'o') {
+                if (self.peek == 'o') {
                     self.getc();
-                    if(self.peek == 'n') {
+                    if (self.peek == 'n') {
                         self.getc();
                         //Keyword_const
-                        if(self.peek == 's') {
-                            if(self.getcx() != 't') return self.identifier();
+                        if (self.peek == 's') {
+                            if (self.getcx() != 't') return self.identifier();
                             self.getc();
                             return self.identifierOr(Id.Keyword_const);
                         }
                         //Keyword_continue
-                        if(self.peek == 't') {
-                            if(self.getcx() != 'i') return self.identifier();
-                            if(self.getcx() != 'n') return self.identifier();
-                            if(self.getcx() != 'u') return self.identifier();
-                            if(self.getcx() != 'e') return self.identifier();
+                        if (self.peek == 't') {
+                            if (self.getcx() != 'i') return self.identifier();
+                            if (self.getcx() != 'n') return self.identifier();
+                            if (self.getcx() != 'u') return self.identifier();
+                            if (self.getcx() != 'e') return self.identifier();
                             self.getc();
                             return self.identifierOr(Id.Keyword_continue);
                         }
                         return self.identifier();
                     }
                     //Keyword_comptime
-                    if(self.peek == 'm') {
-                        if(self.getcx() != 'p') return self.identifier();
-                        if(self.getcx() != 't') return self.identifier();
-                        if(self.getcx() != 'i') return self.identifier();
-                        if(self.getcx() != 'm') return self.identifier();
-                        if(self.getcx() != 'e') return self.identifier();
+                    if (self.peek == 'm') {
+                        if (self.getcx() != 'p') return self.identifier();
+                        if (self.getcx() != 't') return self.identifier();
+                        if (self.getcx() != 'i') return self.identifier();
+                        if (self.getcx() != 'm') return self.identifier();
+                        if (self.getcx() != 'e') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_comptime);
                     }
                     return self.identifier();
                 }
-                if(self.peek == 'a') {
+                if (self.peek == 'a') {
                     self.getc();
                     //Keyword_catch
-                    if(self.peek == 't') {
-                        if(self.getcx() != 'c') return self.identifier();
-                        if(self.getcx() != 'h') return self.identifier();
+                    if (self.peek == 't') {
+                        if (self.getcx() != 'c') return self.identifier();
+                        if (self.getcx() != 'h') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_catch);
                     }
                     //Keyword_cancel
-                    if(self.peek == 'n') {
-                        if(self.getcx() != 'c') return self.identifier();
-                        if(self.getcx() != 'e') return self.identifier();
-                        if(self.getcx() != 'l') return self.identifier();
+                    if (self.peek == 'n') {
+                        if (self.getcx() != 'c') return self.identifier();
+                        if (self.getcx() != 'e') return self.identifier();
+                        if (self.getcx() != 'l') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_cancel);
                     }
                     return self.identifier();
                 }
                 // CString
-                if(self.peek == '"') {
+                if (self.peek == '"') {
                     self.getc();
                     return self.string();
                 }
                 // LineCString
-                if(self.peek == '\\') {
-                    if(self.getcx() != '\\') return Id.Invalid;
+                if (self.peek == '\\') {
+                    if (self.getcx() != '\\') return Id.Invalid;
                     return self.linestring(Id.LineCString);
                 }
                 return self.identifier();
             },
             'd' => {
                 //Keyword_defer
-                if(self.peek != 'e') return self.identifier();
-                if(self.getcx() != 'f') return self.identifier();
-                if(self.getcx() != 'e') return self.identifier();
-                if(self.getcx() != 'r') return self.identifier();
+                if (self.peek != 'e') return self.identifier();
+                if (self.getcx() != 'f') return self.identifier();
+                if (self.getcx() != 'e') return self.identifier();
+                if (self.getcx() != 'r') return self.identifier();
                 self.getc();
                 return self.identifierOr(Id.Keyword_defer);
             },
             'e' => {
                 //Keyword_else
-                if(self.peek == 'l') {
-                    if(self.getcx() != 's') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
+                if (self.peek == 'l') {
+                    if (self.getcx() != 's') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_else);
                 }
-                if(self.peek == 'r') {
-                    if(self.getcx() != 'r') return self.identifier();
+                if (self.peek == 'r') {
+                    if (self.getcx() != 'r') return self.identifier();
                     self.getc();
                     //Keyword_errdefer
-                    if(self.peek == 'd') {
-                        if(self.getcx() != 'e') return self.identifier();
-                        if(self.getcx() != 'f') return self.identifier();
-                        if(self.getcx() != 'e') return self.identifier();
-                        if(self.getcx() != 'r') return self.identifier();
+                    if (self.peek == 'd') {
+                        if (self.getcx() != 'e') return self.identifier();
+                        if (self.getcx() != 'f') return self.identifier();
+                        if (self.getcx() != 'e') return self.identifier();
+                        if (self.getcx() != 'r') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_errdefer);
                     }
                     //Keyword_error
-                    if(self.peek == 'o') {
-                        if(self.getcx() != 'r') return self.identifier();
+                    if (self.peek == 'o') {
+                        if (self.getcx() != 'r') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_error);
                     }
                     return self.identifier();
                 }
                 //Keyword_enum
-                if(self.peek == 'n') {
-                    if(self.getcx() != 'u') return self.identifier();
-                    if(self.getcx() != 'm') return self.identifier();
+                if (self.peek == 'n') {
+                    if (self.getcx() != 'u') return self.identifier();
+                    if (self.getcx() != 'm') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_enum);
                 }
-                if(self.peek == 'x') {
+                if (self.peek == 'x') {
                     self.getc();
                     //Keyword_extern
-                    if(self.peek == 't') {
-                        if(self.getcx() != 'e') return self.identifier();
-                        if(self.getcx() != 'r') return self.identifier();
-                        if(self.getcx() != 'n') return self.identifier();
+                    if (self.peek == 't') {
+                        if (self.getcx() != 'e') return self.identifier();
+                        if (self.getcx() != 'r') return self.identifier();
+                        if (self.getcx() != 'n') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_extern);
                     }
                     //Keyword_export
-                    if(self.peek == 'p') {
-                        if(self.getcx() != 'o') return self.identifier();
-                        if(self.getcx() != 'r') return self.identifier();
-                        if(self.getcx() != 't') return self.identifier();
+                    if (self.peek == 'p') {
+                        if (self.getcx() != 'o') return self.identifier();
+                        if (self.getcx() != 'r') return self.identifier();
+                        if (self.getcx() != 't') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_export);
                     }
@@ -643,21 +653,21 @@ pub const Lexer = struct {
             },
             'f' => {
                 //Keyword_fn
-                if(self.peek == 'n') {
+                if (self.peek == 'n') {
                     self.getc();
                     return self.identifierOr(Id.Keyword_fn);
                 }
                 //Keyword_for
-                if(self.peek == 'o') {
-                    if(self.getcx() != 'r') return self.identifier();
+                if (self.peek == 'o') {
+                    if (self.getcx() != 'r') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_for);
                 }
                 //Keyword_false
-                if(self.peek == 'a') {
-                    if(self.getcx() != 'l') return self.identifier();
-                    if(self.getcx() != 's') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
+                if (self.peek == 'a') {
+                    if (self.getcx() != 'l') return self.identifier();
+                    if (self.getcx() != 's') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_false);
                 }
@@ -665,16 +675,16 @@ pub const Lexer = struct {
             },
             'i' => {
                 //Keyword_if
-                if(self.peek == 'f') {
+                if (self.peek == 'f') {
                     self.getc();
                     return self.identifierOr(Id.Keyword_if);
                 }
                 //Keyword_inline
-                if(self.peek == 'n') {
-                    if(self.getcx() != 'l') return self.identifier();
-                    if(self.getcx() != 'i') return self.identifier();
-                    if(self.getcx() != 'n') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
+                if (self.peek == 'n') {
+                    if (self.getcx() != 'l') return self.identifier();
+                    if (self.getcx() != 'i') return self.identifier();
+                    if (self.getcx() != 'n') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_inline);
                 }
@@ -682,247 +692,247 @@ pub const Lexer = struct {
             },
             'l' => {
                 //Keyword_linksection
-                if(self.peek != 'i') return self.identifier();
-                if(self.getcx() != 'n') return self.identifier();
-                if(self.getcx() != 'k') return self.identifier();
-                if(self.getcx() != 's') return self.identifier();
-                if(self.getcx() != 'e') return self.identifier();
-                if(self.getcx() != 'c') return self.identifier();
-                if(self.getcx() != 't') return self.identifier();
-                if(self.getcx() != 'i') return self.identifier();
-                if(self.getcx() != 'o') return self.identifier();
-                if(self.getcx() != 'n') return self.identifier();
+                if (self.peek != 'i') return self.identifier();
+                if (self.getcx() != 'n') return self.identifier();
+                if (self.getcx() != 'k') return self.identifier();
+                if (self.getcx() != 's') return self.identifier();
+                if (self.getcx() != 'e') return self.identifier();
+                if (self.getcx() != 'c') return self.identifier();
+                if (self.getcx() != 't') return self.identifier();
+                if (self.getcx() != 'i') return self.identifier();
+                if (self.getcx() != 'o') return self.identifier();
+                if (self.getcx() != 'n') return self.identifier();
                 self.getc();
                 return self.identifierOr(Id.Keyword_linksection);
             },
             'n' => {
                 //Keyword_null
-                if(self.peek == 'u') {
-                    if(self.getcx() != 'l') return self.identifier();
-                    if(self.getcx() != 'l') return self.identifier();
+                if (self.peek == 'u') {
+                    if (self.getcx() != 'l') return self.identifier();
+                    if (self.getcx() != 'l') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_null);
                 }
                 //Keyword_noalias
-                if(self.peek == 'o') {
-                    if(self.getcx() != 'a') return self.identifier();
-                    if(self.getcx() != 'l') return self.identifier();
-                    if(self.getcx() != 'i') return self.identifier();
-                    if(self.getcx() != 'a') return self.identifier();
-                    if(self.getcx() != 's') return self.identifier();
+                if (self.peek == 'o') {
+                    if (self.getcx() != 'a') return self.identifier();
+                    if (self.getcx() != 'l') return self.identifier();
+                    if (self.getcx() != 'i') return self.identifier();
+                    if (self.getcx() != 'a') return self.identifier();
+                    if (self.getcx() != 's') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_noalias);
                 }
                 //Keyword_nakedcc
-                if(self.peek == 'a') {
-                    if(self.getcx() != 'k') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
-                    if(self.getcx() != 'd') return self.identifier();
-                    if(self.getcx() != 'c') return self.identifier();
-                    if(self.getcx() != 'c') return self.identifier();
+                if (self.peek == 'a') {
+                    if (self.getcx() != 'k') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
+                    if (self.getcx() != 'd') return self.identifier();
+                    if (self.getcx() != 'c') return self.identifier();
+                    if (self.getcx() != 'c') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_nakedcc);
                 }
                 return self.identifier();
             },
             'o' => {
-                if(self.peek != 'r') return self.identifier();
+                if (self.peek != 'r') return self.identifier();
                 //Keyword_or
-                if(self.getcx() != 'e') return self.identifierOr(Id.Keyword_or);
+                if (self.getcx() != 'e') return self.identifierOr(Id.Keyword_or);
                 //Keyword_orelse
-                if(self.getcx() != 'l') return self.identifier();
-                if(self.getcx() != 's') return self.identifier();
-                if(self.getcx() != 'e') return self.identifier();
+                if (self.getcx() != 'l') return self.identifier();
+                if (self.getcx() != 's') return self.identifier();
+                if (self.getcx() != 'e') return self.identifier();
                 self.getc();
                 return self.identifierOr(Id.Keyword_orelse);
             },
             'p' => {
                 //Keyword_pub
-                if(self.peek == 'u') {
-                    if(self.getcx() != 'b') return self.identifier();
+                if (self.peek == 'u') {
+                    if (self.getcx() != 'b') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_pub);
                 }
                 //Keyword_packed
-                if(self.peek == 'a') {
-                    if(self.getcx() != 'c') return self.identifier();
-                    if(self.getcx() != 'k') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
-                    if(self.getcx() != 'd') return self.identifier();
+                if (self.peek == 'a') {
+                    if (self.getcx() != 'c') return self.identifier();
+                    if (self.getcx() != 'k') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
+                    if (self.getcx() != 'd') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_packed);
                 }
                 //Keyword_promise
-                if(self.peek == 'r') {
-                    if(self.getcx() != 'o') return self.identifier();
-                    if(self.getcx() != 'm') return self.identifier();
-                    if(self.getcx() != 'i') return self.identifier();
-                    if(self.getcx() != 's') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
+                if (self.peek == 'r') {
+                    if (self.getcx() != 'o') return self.identifier();
+                    if (self.getcx() != 'm') return self.identifier();
+                    if (self.getcx() != 'i') return self.identifier();
+                    if (self.getcx() != 's') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_promise);
                 }
                 return self.identifier();
             },
             'r' => {
-                if(self.peek != 'e') return self.identifier();
+                if (self.peek != 'e') return self.identifier();
                 self.getc();
                 //Keyword_return
-                if(self.peek == 't') {
-                    if(self.getcx() != 'u') return self.identifier();
-                    if(self.getcx() != 'r') return self.identifier();
-                    if(self.getcx() != 'n') return self.identifier();
+                if (self.peek == 't') {
+                    if (self.getcx() != 'u') return self.identifier();
+                    if (self.getcx() != 'r') return self.identifier();
+                    if (self.getcx() != 'n') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_return);
                 }
                 //Keyword_resume
-                if(self.peek == 's') {
-                    if(self.getcx() != 'u') return self.identifier();
-                    if(self.getcx() != 'm') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
+                if (self.peek == 's') {
+                    if (self.getcx() != 'u') return self.identifier();
+                    if (self.getcx() != 'm') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_resume);
                 }
                 return self.identifier();
             },
             's' => {
-                if(self.peek == 't') {
+                if (self.peek == 't') {
                     self.getc();
                     //Keyword_struct
-                    if(self.peek == 'r') {
-                        if(self.getcx() != 'u') return self.identifier();
-                        if(self.getcx() != 'c') return self.identifier();
-                        if(self.getcx() != 't') return self.identifier();
+                    if (self.peek == 'r') {
+                        if (self.getcx() != 'u') return self.identifier();
+                        if (self.getcx() != 'c') return self.identifier();
+                        if (self.getcx() != 't') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_struct);
                     }
                     //Keyword_stdcallcc
-                    if(self.peek == 'd') {
-                        if(self.getcx() != 'c') return self.identifier();
-                        if(self.getcx() != 'a') return self.identifier();
-                        if(self.getcx() != 'l') return self.identifier();
-                        if(self.getcx() != 'l') return self.identifier();
-                        if(self.getcx() != 'c') return self.identifier();
-                        if(self.getcx() != 'c') return self.identifier();
+                    if (self.peek == 'd') {
+                        if (self.getcx() != 'c') return self.identifier();
+                        if (self.getcx() != 'a') return self.identifier();
+                        if (self.getcx() != 'l') return self.identifier();
+                        if (self.getcx() != 'l') return self.identifier();
+                        if (self.getcx() != 'c') return self.identifier();
+                        if (self.getcx() != 'c') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_stdcallcc);
                     }
                     return self.identifier();
                 }
                 //Keyword_switch
-                if(self.peek == 'w') {
-                    if(self.getcx() != 'i') return self.identifier();
-                    if(self.getcx() != 't') return self.identifier();
-                    if(self.getcx() != 'c') return self.identifier();
-                    if(self.getcx() != 'h') return self.identifier();
+                if (self.peek == 'w') {
+                    if (self.getcx() != 'i') return self.identifier();
+                    if (self.getcx() != 't') return self.identifier();
+                    if (self.getcx() != 'c') return self.identifier();
+                    if (self.getcx() != 'h') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_switch);
                 }
                 //Keyword_suspend
-                if(self.peek == 'u') {
-                    if(self.getcx() != 's') return self.identifier();
-                    if(self.getcx() != 'p') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
-                    if(self.getcx() != 'n') return self.identifier();
-                    if(self.getcx() != 'd') return self.identifier();
+                if (self.peek == 'u') {
+                    if (self.getcx() != 's') return self.identifier();
+                    if (self.getcx() != 'p') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
+                    if (self.getcx() != 'n') return self.identifier();
+                    if (self.getcx() != 'd') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_suspend);
                 }
                 return self.identifier();
             },
             't' => {
-                if(self.peek == 'r') {
+                if (self.peek == 'r') {
                     self.getc();
                     //Keyword_try
-                    if(self.peek == 'y') {
+                    if (self.peek == 'y') {
                         self.getc();
                         return self.identifierOr(Id.Keyword_try);
                     }
                     //Keyword_true
-                    if(self.peek == 'u') {
-                        if(self.getcx() != 'e') return self.identifier();
+                    if (self.peek == 'u') {
+                        if (self.getcx() != 'e') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_true);
                     }
                     return self.identifier();
                 }
                 //Keyword_test
-                if(self.peek == 'e') {
-                    if(self.getcx() != 's') return self.identifier();
-                    if(self.getcx() != 't') return self.identifier();
+                if (self.peek == 'e') {
+                    if (self.getcx() != 's') return self.identifier();
+                    if (self.getcx() != 't') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_test);
                 }
                 //Keyword_threadlocal
-                if(self.peek == 'h') {
-                    if(self.getcx() != 'r') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
-                    if(self.getcx() != 'a') return self.identifier();
-                    if(self.getcx() != 'd') return self.identifier();
-                    if(self.getcx() != 'l') return self.identifier();
-                    if(self.getcx() != 'o') return self.identifier();
-                    if(self.getcx() != 'c') return self.identifier();
-                    if(self.getcx() != 'a') return self.identifier();
-                    if(self.getcx() != 'l') return self.identifier();
+                if (self.peek == 'h') {
+                    if (self.getcx() != 'r') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
+                    if (self.getcx() != 'a') return self.identifier();
+                    if (self.getcx() != 'd') return self.identifier();
+                    if (self.getcx() != 'l') return self.identifier();
+                    if (self.getcx() != 'o') return self.identifier();
+                    if (self.getcx() != 'c') return self.identifier();
+                    if (self.getcx() != 'a') return self.identifier();
+                    if (self.getcx() != 'l') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_threadlocal);
                 }
                 return self.identifier();
             },
             'u' => {
-                if(self.peek == 's') {
+                if (self.peek == 's') {
                     self.getc();
                     //Keyword_use
-                    if(self.peek == 'e') {
+                    if (self.peek == 'e') {
                         self.getc();
                         return self.identifierOr(Id.Keyword_use);
                     }
                     //Keyword_usingnamespace
-                    if(self.peek != 'i') return self.identifier();
-                    if(self.getcx() != 'n') return self.identifier();
-                    if(self.getcx() != 'g') return self.identifier();
-                    if(self.getcx() != 'n') return self.identifier();
-                    if(self.getcx() != 'a') return self.identifier();
-                    if(self.getcx() != 'm') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
-                    if(self.getcx() != 's') return self.identifier();
-                    if(self.getcx() != 'p') return self.identifier();
-                    if(self.getcx() != 'a') return self.identifier();
-                    if(self.getcx() != 'c') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
+                    if (self.peek != 'i') return self.identifier();
+                    if (self.getcx() != 'n') return self.identifier();
+                    if (self.getcx() != 'g') return self.identifier();
+                    if (self.getcx() != 'n') return self.identifier();
+                    if (self.getcx() != 'a') return self.identifier();
+                    if (self.getcx() != 'm') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
+                    if (self.getcx() != 's') return self.identifier();
+                    if (self.getcx() != 'p') return self.identifier();
+                    if (self.getcx() != 'a') return self.identifier();
+                    if (self.getcx() != 'c') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_usingnamespace);
                 }
-                if(self.peek == 'n') {
+                if (self.peek == 'n') {
                     self.getc();
                     //Keyword_union
-                    if(self.peek == 'i') {
-                        if(self.getcx() != 'o') return self.identifier();
-                        if(self.getcx() != 'n') return self.identifier();
+                    if (self.peek == 'i') {
+                        if (self.getcx() != 'o') return self.identifier();
+                        if (self.getcx() != 'n') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_union);
                     }
                     //Keyword_undefined
-                    if(self.peek == 'd') {
-                        if(self.getcx() != 'e') return self.identifier();
-                        if(self.getcx() != 'f') return self.identifier();
-                        if(self.getcx() != 'i') return self.identifier();
-                        if(self.getcx() != 'n') return self.identifier();
-                        if(self.getcx() != 'e') return self.identifier();
-                        if(self.getcx() != 'd') return self.identifier();
+                    if (self.peek == 'd') {
+                        if (self.getcx() != 'e') return self.identifier();
+                        if (self.getcx() != 'f') return self.identifier();
+                        if (self.getcx() != 'i') return self.identifier();
+                        if (self.getcx() != 'n') return self.identifier();
+                        if (self.getcx() != 'e') return self.identifier();
+                        if (self.getcx() != 'd') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_undefined);
                     }
                     //Keyword_unreachable
-                    if(self.peek == 'r') {
-                        if(self.getcx() != 'e') return self.identifier();
-                        if(self.getcx() != 'a') return self.identifier();
-                        if(self.getcx() != 'c') return self.identifier();
-                        if(self.getcx() != 'h') return self.identifier();
-                        if(self.getcx() != 'a') return self.identifier();
-                        if(self.getcx() != 'b') return self.identifier();
-                        if(self.getcx() != 'l') return self.identifier();
-                        if(self.getcx() != 'e') return self.identifier();
+                    if (self.peek == 'r') {
+                        if (self.getcx() != 'e') return self.identifier();
+                        if (self.getcx() != 'a') return self.identifier();
+                        if (self.getcx() != 'c') return self.identifier();
+                        if (self.getcx() != 'h') return self.identifier();
+                        if (self.getcx() != 'a') return self.identifier();
+                        if (self.getcx() != 'b') return self.identifier();
+                        if (self.getcx() != 'l') return self.identifier();
+                        if (self.getcx() != 'e') return self.identifier();
                         self.getc();
                         return self.identifierOr(Id.Keyword_unreachable);
                     }
@@ -930,19 +940,19 @@ pub const Lexer = struct {
             },
             'v' => {
                 //Keyword_var
-                if(self.peek == 'a') {
-                    if(self.getcx() != 'r') return self.identifier();
+                if (self.peek == 'a') {
+                    if (self.getcx() != 'r') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_var);
                 }
                 //Keyword_volatile
-                if(self.peek == 'o') {
-                    if(self.getcx() != 'l') return self.identifier();
-                    if(self.getcx() != 'a') return self.identifier();
-                    if(self.getcx() != 't') return self.identifier();
-                    if(self.getcx() != 'i') return self.identifier();
-                    if(self.getcx() != 'l') return self.identifier();
-                    if(self.getcx() != 'e') return self.identifier();
+                if (self.peek == 'o') {
+                    if (self.getcx() != 'l') return self.identifier();
+                    if (self.getcx() != 'a') return self.identifier();
+                    if (self.getcx() != 't') return self.identifier();
+                    if (self.getcx() != 'i') return self.identifier();
+                    if (self.getcx() != 'l') return self.identifier();
+                    if (self.getcx() != 'e') return self.identifier();
                     self.getc();
                     return self.identifierOr(Id.Keyword_volatile);
                 }
@@ -950,28 +960,28 @@ pub const Lexer = struct {
             },
             'w' => {
                 //Keyword_while
-                if(self.peek != 'h') return self.identifier();
-                if(self.getcx() != 'i') return self.identifier();
-                if(self.getcx() != 'l') return self.identifier();
-                if(self.getcx() != 'e') return self.identifier();
+                if (self.peek != 'h') return self.identifier();
+                if (self.getcx() != 'i') return self.identifier();
+                if (self.getcx() != 'l') return self.identifier();
+                if (self.getcx() != 'e') return self.identifier();
                 self.getc();
                 return self.identifierOr(Id.Keyword_while);
             },
             '{' => {
-                if(self.index == 1)
+                if (self.index == 1)
                     return Id.LBrace;
 
-                switch(self.source[self.index-2]) {
+                switch (self.source[self.index - 2]) {
                     '(', ':', ' ', '\t', '\r', '\n' => return Id.LBrace,
                     else => return Id.LCurly,
                 }
             },
             '|' => {
-                if(self.peek == '=') {
+                if (self.peek == '=') {
                     self.getc();
                     return Id.PipeEqual;
                 }
-                if(self.peek == '|') {
+                if (self.peek == '|') {
                     self.getc();
                     return Id.PipePipe;
                 }
@@ -984,9 +994,9 @@ pub const Lexer = struct {
                 return Id.Tilde;
             },
             '0' => {
-                if(self.peek == 'x') return self.hex();
-                if(self.peek == 'o') return self.octal();
-                if(self.peek == 'b') return self.binary();
+                if (self.peek == 'x') return self.hex();
+                if (self.peek == 'o') return self.octal();
+                if (self.peek == 'b') return self.binary();
                 return self.digits();
             },
             '1'...'9' => {
@@ -994,7 +1004,7 @@ pub const Lexer = struct {
             },
             else => {},
         }
-        if(identifier_state[@bitCast(u8,peek)] == 1)
+        if (identifier_state[@bitCast(u8, peek)] == 1)
             return self.identifier();
         return Id.Invalid;
     }
@@ -1002,10 +1012,10 @@ pub const Lexer = struct {
 
 pub fn main() void {
     var lexer = Lexer.init("while(true) { var @vv; volatile; }");
-    while(true) {
+    while (true) {
         const token = lexer.next();
         warn("{}\n", token);
-        if(token.id == .Eof)
+        if (token.id == .Eof)
             break;
     }
 }

--- a/zig/zig_parser.zig
+++ b/zig/zig_parser.zig
@@ -443,7 +443,7 @@ pub const Parser = struct {
         self.tokens = std.ArrayList(Token).init(self.allocator);
         errdefer self.tokens.deinit();
 
-        try self.tokens.ensureCapacity((buffer.len*10)/8);
+        try self.tokens.ensureCapacity((buffer.len * 10) / 8);
 
         var lexer = Lexer.init(buffer);
 
@@ -454,13 +454,13 @@ pub const Parser = struct {
             if (token.id == .Eof)
                 break;
         }
-        const shebang = if (self.tokens.items[1].id == .ShebangLine) usize(1) else usize(0);
+        const shebang = if (self.tokens.items[1].id == .ShebangLine) @as(usize, 1) else @as(usize, 0);
         var i: usize = shebang + 1;
         // If file starts with a DocComment this is considered a RootComment
         while (i < self.tokens.len) : (i += 1) {
             self.tokens.items[i].id = if (self.tokens.items[i].id == .DocComment) .RootDocComment else break;
         }
-        i = shebang+1;
+        i = shebang + 1;
         var line: usize = 1;
         var last_newline = &self.tokens.items[0];
         var resync_progress: usize = 0;
@@ -513,23 +513,23 @@ pub const Parser = struct {
             break :parser_loop;
         }
         // Aborted parse may overrun counter
-        if(i >= self.tokens.len) i = self.tokens.len-1;
+        if (i >= self.tokens.len) i = self.tokens.len - 1;
 
         stack_trace("\n");
         if (self.engine.stack.len > 0) {
             const Root = @intToPtr(?*Node.Root, self.engine.stack.at(0).item) orelse {
-                if(self.engine.errors.len > 0 and self.engine.errors.at(self.engine.errors.len-1).info == .AbortedParse)
+                if (self.engine.errors.len > 0 and self.engine.errors.at(self.engine.errors.len - 1).info == .AbortedParse)
                     return false;
                 try self.engine.reportError(ParseError.AbortedParse, &self.tokens.items[i]);
                 return false;
             };
-            if(shebang != 0)
+            if (shebang != 0)
                 Root.shebang_token = &self.tokens.items[1];
             Root.eof_token = &self.tokens.items[self.tokens.len - 1];
             self.root = Root;
             return true;
         }
-        if(self.engine.errors.len > 0 and self.engine.errors.at(self.engine.errors.len-1).info == .AbortedParse)
+        if (self.engine.errors.len > 0 and self.engine.errors.at(self.engine.errors.len - 1).info == .AbortedParse)
             return false;
 
         try self.engine.reportError(ParseError.AbortedParse, &self.tokens.items[i]);


### PR DESCRIPTION
After pulling latest master of the zig compiler, zig-lsp no longer compiles. I have updated the code (mainly changing to use the new `@as(usize, 0)` syntax for type coercion.

Zig format also ran on save and I noticed a few things changed, sorry about that. I can try to disable it and redo the changes?

Additionally, zig-lsp does not yet support anonymous struct literals yet. What would it take to support them?